### PR TITLE
Pause the engine when the main window loses focus

### DIFF
--- a/OpenGLGame/clock.h
+++ b/OpenGLGame/clock.h
@@ -5,6 +5,9 @@
 
 typedef struct
 {
+   cBool_t isRunning;
+   uint64_t pauseTimeMicro;
+
    uint32_t totalFrames;
    uint32_t lagFrames;
    uint64_t absoluteStartMicro;
@@ -12,6 +15,7 @@ typedef struct
    uint64_t totalTimeMicro;
    uint64_t lastFrameDurationMicro;
    uint64_t targetFrameDurationMicro;
+
    float frameDeltaSeconds;
 }
 cClock_t;
@@ -19,5 +23,7 @@ cClock_t;
 void cClock_Init( cClock_t* clock );
 void cClock_StartFrame( cClock_t* clock );
 void cClock_EndFrame( cClock_t* clock );
+void cClock_Pause( cClock_t* clock );
+void cClock_Resume( cClock_t* clock );
 
 #endif

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -11,6 +11,7 @@ void cGame_Init( cGameData_t* gameData )
    cInput_Init( gameData->keyStates );
 
    gameData->isRunning = cFalse;
+   gameData->isEngineRunning = cTrue;
 }
 
 void cGame_Run( cGameData_t* gameData )
@@ -19,13 +20,38 @@ void cGame_Run( cGameData_t* gameData )
 
    while ( gameData->isRunning )
    {
-      cClock_StartFrame( &( gameData->clock ) );
-      cInput_UpdateStates( gameData->keyStates );
-      Platform_Tick();
-      cGame_HandleInput( gameData );
-      cGame_Tick( gameData );
-      cGame_Render( gameData );
-      cClock_EndFrame( &( gameData->clock ) );
+      if ( gameData->isEngineRunning )
+      {
+         cClock_StartFrame( &( gameData->clock ) );
+         cInput_UpdateStates( gameData->keyStates );
+         Platform_Tick();
+         cGame_HandleInput( gameData );
+         cGame_Tick( gameData );
+         cGame_Render( gameData );
+         cClock_EndFrame( &( gameData->clock ) );
+      }
+      else
+      {
+         Platform_Tick();
+      }
+   }
+}
+
+void cGame_PauseEngine( cGameData_t* gameData )
+{
+   if ( gameData->isEngineRunning )
+   {
+      cClock_Pause( &( gameData->clock ) );
+      gameData->isEngineRunning = cFalse;
+   }
+}
+
+void cGame_ResumeEngine( cGameData_t* gameData )
+{
+   if ( !gameData->isEngineRunning )
+   {
+      gameData->isEngineRunning = cTrue;
+      cClock_Resume( &( gameData->clock ) );
    }
 }
 

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -63,7 +63,7 @@ void cGame_EmergencySave( cGameData_t* gameData )
 
 void cGame_TryClose( cGameData_t* gameData )
 {
-   // NOTE: this means the user is trying to exit the game prematurely,
+   // NOTE: the user could be trying to exit the game prematurely,
    // so give them the chance to save or whatever before it happens.
    gameData->isRunning = cFalse;
 }

--- a/OpenGLGame/game.h
+++ b/OpenGLGame/game.h
@@ -10,11 +10,14 @@ typedef struct
    cClock_t clock;
    cKeyState_t keyStates[cKeyCode_Count];
    cBool_t isRunning;
+   cBool_t isEngineRunning;
 }
 cGameData_t;
 
 void cGame_Init( cGameData_t* gameData );
 void cGame_Run( cGameData_t* gameData );
+void cGame_PauseEngine( cGameData_t* gameData );
+void cGame_ResumeEngine( cGameData_t* gameData );
 void cGame_EmergencySave( cGameData_t* gameData );
 void cGame_TryClose( cGameData_t* gameData );
 

--- a/OpenGLGame/platform_win.c
+++ b/OpenGLGame/platform_win.c
@@ -176,6 +176,14 @@ internal LRESULT CALLBACK MainWindowProc( _In_ HWND hWnd, _In_ UINT uMsg, _In_ W
       case WM_SYSKEYUP:
          HandleKeyboardInput( (uint32_t)wParam, lParam );
          break;
+      case WM_KILLFOCUS:
+         cGame_PauseEngine( &( g_globals.gameData ) );
+         DefWindowProc( hWnd, uMsg, wParam, lParam );
+         break;
+      case WM_SETFOCUS:
+         cGame_ResumeEngine( &( g_globals.gameData ) );
+         DefWindowProc( hWnd, uMsg, wParam, lParam );
+         break;
       default:
          result = DefWindowProc( hWnd, uMsg, wParam, lParam );
    }

--- a/OpenGLGame/platform_win.c
+++ b/OpenGLGame/platform_win.c
@@ -160,6 +160,7 @@ internal LRESULT CALLBACK MainWindowProc( _In_ HWND hWnd, _In_ UINT uMsg, _In_ W
 
    switch ( uMsg )
    {
+      case WM_QUIT:
       case WM_CLOSE:
          cGame_TryClose( &( g_globals.gameData ) );
          break;
@@ -307,16 +308,8 @@ void Platform_Tick()
 
    while ( PeekMessage( &msg, g_globals.hWndMain, 0, 0, PM_REMOVE ) )
    {
-      if ( msg.message == WM_QUIT )
-      {
-         cGame_TryClose( &( g_globals.gameData ) );
-         break;
-      }
-      else
-      {
-         TranslateMessage( &msg );
-         DispatchMessage( &msg );
-      }
+      TranslateMessage( &msg );
+      DispatchMessage( &msg );
    }
 }
 


### PR DESCRIPTION
## Overview

This adds a couple listeners to the Windows message loop so we can tell when the main window loses and regains focus. In that case we want to stop the engine and the clock, but keep the message loop running.