### PR TITLE
Add support for 32-bit bitmaps

### DIFF
--- a/OpenGLGame/strings.h
+++ b/OpenGLGame/strings.h
@@ -26,6 +26,7 @@
 #define STR_BMPERR_INVALIDIMAGESIZE       "BMP error: invalid image size: %s"
 #define STR_BMPERR_INVALIDPALETTECOUNT    "BMP error: invalid number of palette colors: %s"
 #define STR_BMPERR_PALETTECORRUPT         "BMP error: palette is corrupt: %s"
+#define STR_BMPERR_INVALIDCOLORINDEXING   "BMP error: color indexing is not currently supported: %s"
 
 #define STR_WIN_WINDOWTITLE               "Testing"
 


### PR DESCRIPTION
## Overview

This adds support for 32-bit BMP files. For now we're ignoring the `BITMAPV5HEADER` fields regarding color indexing, color masking, and basically anything else, so we're just assuming that the image bytes are in ARGB format.