### PR TITLE
Actually log messages to a log file

### DIFF
--- a/OpenGLGame/common.h
+++ b/OpenGLGame/common.h
@@ -20,6 +20,8 @@ typedef int32_t Bool_t;
 #define False 0
 #define TOGGLE_BOOL( x ) x = ( x ) ? False : True
 
+#define LOG_FILE_NAME            "log.txt"
+
 #define STRING_SIZE_DEFAULT      1024
 
 #define GRAPHICS_BPP             32

--- a/OpenGLGame/strings.h
+++ b/OpenGLGame/strings.h
@@ -16,6 +16,8 @@
 #define STR_WINERR_LOGMESSAGE             "Windows error: %s"
 #define STR_WINERR_APPDIRECTORY           "Failed to get the app's base directory."
 #define STR_WINERR_INITGAME               "Failed to initialize game."
+#define STR_WINERR_CREATELOGFILE          "Failed to open log file."
+#define STR_WINERR_WRITELOGFILE           "Failed to write message to log file."
 
 #define STR_FILEERR_OPENFILEFAILED        "File error: could not open file: %s"
 #define STR_FILEERR_GETFILESIZEFAILED     "File error: could not get file size: %s"


### PR DESCRIPTION
## Overview

When logging a message, it should now get appended to "log.txt", which lives in the exe's root folder. If no messages have ever been logged, the file should not exist, and if it already exists new messages should be appended to the end of the file.