### PR TITLE
Added menus

### DIFF
--- a/OpenGLGame/OpenGLGame.vcxproj
+++ b/OpenGLGame/OpenGLGame.vcxproj
@@ -144,6 +144,7 @@ xcopy "$(SolutionDir)OpenGLGame\assets" "$(OutDir)assets\" /S /Y</Command>
     <ClCompile Include="game.c" />
     <ClCompile Include="clock.c" />
     <ClCompile Include="game_load.c" />
+    <ClCompile Include="game_render.c" />
     <ClCompile Include="input.c" />
     <ClCompile Include="menu.c" />
     <ClCompile Include="random.c" />

--- a/OpenGLGame/OpenGLGame.vcxproj
+++ b/OpenGLGame/OpenGLGame.vcxproj
@@ -143,7 +143,9 @@ xcopy "$(SolutionDir)OpenGLGame\assets" "$(OutDir)assets\" /S /Y</Command>
     <ClCompile Include="font.c" />
     <ClCompile Include="game.c" />
     <ClCompile Include="clock.c" />
+    <ClCompile Include="game_load.c" />
     <ClCompile Include="input.c" />
+    <ClCompile Include="menu.c" />
     <ClCompile Include="random.c" />
     <ClCompile Include="sprite.c" />
     <ClCompile Include="texture.c" />
@@ -156,6 +158,7 @@ xcopy "$(SolutionDir)OpenGLGame\assets" "$(OutDir)assets\" /S /Y</Command>
     <ClInclude Include="common.h" />
     <ClInclude Include="enums.h" />
     <ClInclude Include="font.h" />
+    <ClInclude Include="menu.h" />
     <ClInclude Include="platform_includes.h" />
     <ClInclude Include="sprite.h" />
     <ClInclude Include="texture.h" />

--- a/OpenGLGame/OpenGLGame.vcxproj.filters
+++ b/OpenGLGame/OpenGLGame.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClCompile Include="game_load.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="game_render.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="common.h">

--- a/OpenGLGame/OpenGLGame.vcxproj.filters
+++ b/OpenGLGame/OpenGLGame.vcxproj.filters
@@ -41,6 +41,12 @@
     <ClCompile Include="font.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="menu.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="game_load.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="common.h">
@@ -95,6 +101,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="platform_includes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="menu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/OpenGLGame/enums.h
+++ b/OpenGLGame/enums.h
@@ -12,8 +12,9 @@ TextureID_t;
 
 typedef enum
 {
-   FontID_Consolas = 0,
-   FontID_Papyrus,
+   FontID_Diagnostics = 0,
+   FontID_BrushTeeth,
+   FontID_Menu,
 
    FontID_Count
 }

--- a/OpenGLGame/enums.h
+++ b/OpenGLGame/enums.h
@@ -19,4 +19,13 @@ typedef enum
 }
 FontID_t;
 
+typedef enum
+{
+   GameState_Playing = 0,
+   GameState_Menu,
+
+   GameState_Count
+}
+GameState_t;
+
 #endif

--- a/OpenGLGame/enums.h
+++ b/OpenGLGame/enums.h
@@ -21,6 +21,14 @@ FontID_t;
 
 typedef enum
 {
+   MenuID_Playing = 0,
+
+   MenuID_Count
+}
+MenuID_t;
+
+typedef enum
+{
    GameState_Playing = 0,
    GameState_Menu,
 

--- a/OpenGLGame/enums.h
+++ b/OpenGLGame/enums.h
@@ -30,6 +30,15 @@ MenuID_t;
 
 typedef enum
 {
+   MenuItemID_KeepPlaying = 0,
+   MenuItemID_Quit,
+
+   MenuItemID_Count
+}
+MenuItemID_t;
+
+typedef enum
+{
    GameState_Playing = 0,
    GameState_Menu,
 

--- a/OpenGLGame/enums.h
+++ b/OpenGLGame/enums.h
@@ -12,9 +12,8 @@ TextureID_t;
 
 typedef enum
 {
-   FontID_Diagnostics = 0,
-   FontID_BrushTeeth,
-   FontID_Menu,
+   FontID_Consolas = 0,
+   FontID_Papyrus,
 
    FontID_Count
 }

--- a/OpenGLGame/font.c
+++ b/OpenGLGame/font.c
@@ -98,6 +98,7 @@ Bool_t Font_LoadFromFile( Font_t* font, const char* filePath )
          filePos32 += ( buffer->dimensions.x * buffer->dimensions.y );
          bytesRead += bufferSize;
 
+         glyph->color = 0xFFFFFFFF;
          glyph++;
       }
 
@@ -150,21 +151,13 @@ Bool_t Font_ContainsChar( Font_t* font, uint32_t codepoint )
 
 void Font_SetCharColor( Font_t* font, uint32_t codepoint, uint32_t color )
 {
-   uint32_t i, j;
-   PixelBuffer_t* buffer;
-   uint32_t* memory;
+   uint32_t i;
 
    if ( Font_ContainsChar( font, codepoint ) )
    {
       for ( i = 0; i < font->numGlyphCollections; i++ )
       {
-         buffer = &( font->glyphCollections[i].glyphs[codepoint - font->codepointOffset].pixelBuffer );
-         memory = (uint32_t*)( buffer->memory );
-
-         for ( j = 0; j < ( buffer->dimensions.x * buffer->dimensions.y ); j++ )
-         {
-            memory[j] = ( memory[j] & 0xFF000000 ) | ( color & 0x00FFFFFF );
-         }
+         font->glyphCollections[i].glyphs[codepoint - font->codepointOffset].color = color;
       }
    }
 }

--- a/OpenGLGame/font.h
+++ b/OpenGLGame/font.h
@@ -11,6 +11,7 @@ typedef struct
    float leftBearing;
    float baselineOffset;
    float advance;
+   uint32_t color;
 }
 FontGlyph_t;
 

--- a/OpenGLGame/font.h
+++ b/OpenGLGame/font.h
@@ -35,6 +35,7 @@ typedef struct
 Font_t;
 
 Bool_t Font_LoadFromFile( Font_t* font, const char* filePath );
+void Font_ClearData( Font_t* font );
 Bool_t Font_ContainsChar( Font_t* font, uint32_t codepoint );
 void Font_SetCharColor( Font_t* font, uint32_t codepoint, uint32_t color );
 void Font_SetColor( Font_t* font, uint32_t color );

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -216,6 +216,10 @@ internal void Game_Tick( GameData_t* gameData )
          }
       }
    }
+   else if ( gameData->state == GameState_Menu )
+   {
+      Menu_Tick( &( gameData->menus[gameData->curMenuID] ), &( gameData->clock ) );
+   }
 }
 
 internal void Game_Render( GameData_t* gameData )
@@ -272,18 +276,18 @@ internal void Game_RenderMenu( GameData_t* gameData )
 {
    uint32_t i;
    Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
-   float y = menu->renderData.y;
+   float y = menu->renderData.position.y;
    MenuItem_t* item = menu->items;
    MenuRenderData_t* renderData = &( menu->renderData );
    Font_t* font = renderData->font;
 
    for ( i = 0; i < menu->numItems; i++ )
    {
-      Render_DrawTextLine( item->text, 1.0f, renderData->x, y, font );
+      Render_DrawTextLine( item->text, 1.0f, renderData->position.x, y, font );
 
-      if ( menu->selectedItem == i )
+      if ( menu->selectedItem == i && menu->showCarat )
       {
-         Render_DrawChar( renderData->caratCodepoint, 1.0f, renderData->x + renderData->caratOffset, y, font );
+         Render_DrawChar( renderData->caratCodepoint, 1.0f, renderData->position.x + renderData->caratOffset, y, font );
       }
 
       y -= ( font->curGlyphCollection->height + renderData->lineGap );

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -14,9 +14,6 @@ internal void Game_HandleStateInput_Menu( GameData_t* gameData );
 internal void Game_HandleMenuItem_KeepPlaying( GameData_t* gameData );
 internal void Game_HandleMenuItem_Quit( GameData_t* gameData );
 internal void Game_Tick( GameData_t* gameData );
-internal void Game_Render( GameData_t* gameData );
-internal void Game_RenderWorld( GameData_t* gameData );
-internal void Game_RenderMenu( GameData_t* gameData );
 internal void Game_UpdateStarAsync( StarUpdateData_t* data );
 
 Bool_t Game_Init( GameData_t* gameData )
@@ -210,93 +207,6 @@ internal void Game_Tick( GameData_t* gameData )
    if ( gameData->state == GameState_Menu )
    {
       Menu_Tick( &( gameData->menus[gameData->curMenuID] ), &( gameData->clock ) );
-   }
-}
-
-internal void Game_Render( GameData_t* gameData )
-{
-   float y;
-   Font_t* font = &( gameData->renderData.fonts[FontID_Consolas] );
-   char msg[STRING_SIZE_DEFAULT];
-
-   switch ( gameData->state )
-   {
-      case GameState_Playing:
-         Game_RenderWorld( gameData );
-         break;
-      case GameState_Menu:
-         Game_RenderWorld( gameData );
-         Render_DrawRect( 0.0f, 0.0f, (float)SCREEN_WIDTH, (float)SCREEN_HEIGHT, 0x99000000 );
-         Game_RenderMenu( gameData );
-         break;
-   }
-
-   if ( gameData->showDiagnostics )
-   {
-      Font_SetGlyphCollectionForHeight( font, 12.0f );
-      Font_SetColor( font, 0xFFFFFFFF );
-
-      y = (float)SCREEN_HEIGHT - font->curGlyphCollection->height - 10.0f;
-      snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMETARGETMICRO, gameData->clock.targetFrameDurationMicro );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
-      y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
-      snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMEDURATIONMICRO, gameData->clock.lastFrameDurationMicro );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
-      y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
-      snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_LAGFRAMES, gameData->clock.lagFrames );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
-   }
-
-   Platform_RenderScreen();
-}
-
-internal void Game_RenderWorld( GameData_t* gameData )
-{
-   uint32_t i;
-   Star_t* star;
-   Font_t* font = &( gameData->renderData.fonts[FontID_Papyrus] );
-
-   Render_ClearScreen();
-   Render_DrawTexture( &( gameData->renderData.textures[TextureID_Background] ), 0.0f, 0.0f, 1.0f );
-
-   Font_SetGlyphCollectionForHeight( font, 48.0f );
-   Font_SetColor( font, 0xFF3333CC );
-   Render_DrawTextLine( STR_BRUSHTEETH, 1.0f, 65.0f, 240.0f, font );
-
-   for ( i = 0; i < STAR_COUNT; i++ )
-   {
-      star = &( gameData->stars[i] );
-      Render_DrawSprite( &( star->sprite ), star->position.x, star->position.y, star->scale );
-   }
-}
-
-internal void Game_RenderMenu( GameData_t* gameData )
-{
-   uint32_t i;
-   Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
-   float y = menu->renderData.position.y;
-   float textScale;
-   MenuItem_t* item = menu->items;
-   MenuRenderData_t* renderData = &( menu->renderData );
-   Font_t* font = renderData->font;
-
-   Font_SetGlyphCollectionForHeight( font, menu->renderData.textHeight );
-   Font_SetColor( font, menu->renderData.textColor );
-   Font_SetCharColor( font, menu->renderData.caratCodepoint, menu->renderData.caratColor );
-
-   textScale = menu->renderData.textHeight / font->curGlyphCollection->height;
-
-   for ( i = 0; i < menu->numItems; i++ )
-   {
-      Render_DrawTextLine( item->text, textScale, renderData->position.x, y, font );
-
-      if ( menu->selectedItem == i )
-      {
-         Render_DrawChar( renderData->caratCodepoint, textScale, renderData->position.x + renderData->caratOffset, y, font );
-      }
-
-      y -= ( font->curGlyphCollection->height + renderData->lineGap );
-      item++;
    }
 }
 

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -11,6 +11,8 @@ StarUpdateData_t;
 internal void Game_HandleInput( GameData_t* gameData );
 internal void Game_HandleStateInput_Playing( GameData_t* gameData );
 internal void Game_HandleStateInput_Menu( GameData_t* gameData );
+internal void Game_HandleMenuItem_KeepPlaying( GameData_t* gameData );
+internal void Game_HandleMenuItem_Quit( GameData_t* gameData );
 internal void Game_Tick( GameData_t* gameData );
 internal void Game_Render( GameData_t* gameData );
 internal void Game_RenderWorld( GameData_t* gameData );
@@ -57,6 +59,9 @@ Bool_t Game_Init( GameData_t* gameData )
 
    gameData->stateInputHandlers[GameState_Playing] = Game_HandleStateInput_Playing;
    gameData->stateInputHandlers[GameState_Menu] = Game_HandleStateInput_Menu;
+
+   gameData->menuItemInputHandlers[MenuItemID_KeepPlaying] = Game_HandleMenuItem_KeepPlaying;
+   gameData->menuItemInputHandlers[MenuItemID_Quit] = Game_HandleMenuItem_Quit;
 
    gameData->isRunning = False;
    gameData->isEngineRunning = True;
@@ -149,6 +154,8 @@ internal void Game_HandleStateInput_Playing( GameData_t* gameData )
 {
    if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Escape ) )
    {
+      gameData->curMenuID = MenuID_Playing;
+      Menu_Reset( &( gameData->menus[gameData->curMenuID] ) );
       gameData->state = GameState_Menu;
       gameData->curMenuID = MenuID_Playing;
    }
@@ -156,12 +163,36 @@ internal void Game_HandleStateInput_Playing( GameData_t* gameData )
 
 internal void Game_HandleStateInput_Menu( GameData_t* gameData )
 {
-   // TODO: handle scrolling and selection
+   Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
 
    if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Escape ) )
    {
       gameData->state = GameState_Playing;
+      return;
    }
+   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Up ) )
+   {
+      Menu_DecrementSelectedItem( menu );
+   }
+   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Down ) )
+   {
+      Menu_IncrementSelectedItem( menu );
+   }
+   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Enter ) )
+   {
+      gameData->menuItemInputHandlers[menu->items[menu->selectedItem].ID]( gameData );
+   }
+}
+
+internal void Game_HandleMenuItem_KeepPlaying( GameData_t* gameData )
+{
+   UNUSED_PARAM( gameData );
+   gameData->state = GameState_Playing;
+}
+
+internal void Game_HandleMenuItem_Quit( GameData_t* gameData )
+{
+   Game_TryClose( gameData );
 }
 
 internal void Game_Tick( GameData_t* gameData )

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -28,6 +28,13 @@ Bool_t Game_Init( GameData_t* gameData )
       return False;
    }
 
+   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Diagnostics] ), 12.0f );
+   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_BrushTeeth] ), 48.0f );
+   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Menu] ), 24.0f );
+
+   Font_SetColor( &( gameData->renderData.fonts[FontID_BrushTeeth] ), 0x003333CC );
+   Font_SetColor( &( gameData->renderData.fonts[FontID_Menu] ), 0xFFFF8800 );
+
    for ( i = 0; i < STAR_COUNT; i++ )
    {
       star->isResting = False;
@@ -189,6 +196,7 @@ internal void Game_Render( GameData_t* gameData )
          break;
       case GameState_Menu:
          Game_RenderWorld( gameData );
+         Render_DrawRect( 0.0f, 0.0f, (float)SCREEN_WIDTH, (float)SCREEN_HEIGHT, 0x99000000 );
          Game_RenderMenu( gameData );
          break;
    }
@@ -200,14 +208,14 @@ internal void Game_RenderWorld( GameData_t* gameData )
 {
    uint32_t i;
    Star_t* star;
-   Font_t* consolasFont = & ( gameData->renderData.fonts[FontID_Consolas] );
-   Font_t* papyrusFont = &( gameData->renderData.fonts[FontID_Papyrus] );
+   Font_t* diagFont = &( gameData->renderData.fonts[FontID_Diagnostics] );
+   Font_t* teethFont = &( gameData->renderData.fonts[FontID_BrushTeeth] );
    float y;
    char msg[STRING_SIZE_DEFAULT];
 
    Render_ClearScreen();
    Render_DrawTexture( &( gameData->renderData.textures[TextureID_Background] ), 1.0f, 0.0f, 0.0f );
-   Render_DrawTextLine( STR_BRUSHTEETH, 1.0f, 65.0f, 240.0f, papyrusFont );
+   Render_DrawTextLine( STR_BRUSHTEETH, 1.0f, 65.0f, 240.0f, teethFont );
 
    for ( i = 0; i < STAR_COUNT; i++ )
    {
@@ -217,22 +225,39 @@ internal void Game_RenderWorld( GameData_t* gameData )
 
    if ( gameData->showDiagnostics )
    {
-      y = (float)SCREEN_HEIGHT - consolasFont->curGlyphCollection->height - 10.0f;
+      y = (float)SCREEN_HEIGHT - diagFont->curGlyphCollection->height - 10.0f;
       snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMETARGETMICRO, gameData->clock.targetFrameDurationMicro );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, consolasFont );
-      y -= ( consolasFont->curGlyphCollection->height + consolasFont->curGlyphCollection->lineGap );
+      Render_DrawTextLine( msg, 1.0f, 10.0f, y, diagFont );
+      y -= ( diagFont->curGlyphCollection->height + diagFont->curGlyphCollection->lineGap );
       snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMEDURATIONMICRO, gameData->clock.lastFrameDurationMicro );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, consolasFont );
-      y -= ( consolasFont->curGlyphCollection->height + consolasFont->curGlyphCollection->lineGap );
+      Render_DrawTextLine( msg, 1.0f, 10.0f, y, diagFont );
+      y -= ( diagFont->curGlyphCollection->height + diagFont->curGlyphCollection->lineGap );
       snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_LAGFRAMES, gameData->clock.lagFrames );
-      Render_DrawTextLine( msg, 1.0f, 10.0f, y, consolasFont );
+      Render_DrawTextLine( msg, 1.0f, 10.0f, y, diagFont );
    }
 }
 
 internal void Game_RenderMenu( GameData_t* gameData )
 {
-   // TODO: actually draw the menu
-   UNUSED_PARAM( gameData );
+   uint32_t i;
+   Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
+   float y = menu->renderData.y;
+   MenuItem_t* item = menu->items;
+   MenuRenderData_t* renderData = &( menu->renderData );
+   Font_t* font = renderData->font;
+
+   for ( i = 0; i < menu->numItems; i++ )
+   {
+      Render_DrawTextLine( item->text, 1.0f, renderData->x, y, font );
+
+      if ( menu->selectedItem == i )
+      {
+         Render_DrawChar( renderData->caratCodepoint, 1.0f, renderData->x + renderData->caratOffset, y, font );
+      }
+
+      y -= ( font->curGlyphCollection->height + renderData->lineGap );
+      item++;
+   }
 }
 
 internal void Game_UpdateStarAsync( StarUpdateData_t* data )

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -275,20 +275,24 @@ internal void Game_RenderMenu( GameData_t* gameData )
    uint32_t i;
    Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
    float y = menu->renderData.position.y;
+   float textScale;
    MenuItem_t* item = menu->items;
    MenuRenderData_t* renderData = &( menu->renderData );
    Font_t* font = renderData->font;
 
-   Font_SetGlyphCollectionForHeight( font, 24.0f );
-   Font_SetColor( font, 0xFFFF8800 );
+   Font_SetGlyphCollectionForHeight( font, menu->renderData.textHeight );
+   Font_SetColor( font, menu->renderData.textColor );
+   Font_SetCharColor( font, menu->renderData.caratCodepoint, menu->renderData.caratColor );
+
+   textScale = menu->renderData.textHeight / font->curGlyphCollection->height;
 
    for ( i = 0; i < menu->numItems; i++ )
    {
-      Render_DrawTextLine( item->text, 1.0f, renderData->position.x, y, font );
+      Render_DrawTextLine( item->text, textScale, renderData->position.x, y, font );
 
-      if ( menu->selectedItem == i && menu->showCarat )
+      if ( menu->selectedItem == i )
       {
-         Render_DrawChar( renderData->caratCodepoint, 1.0f, renderData->position.x + renderData->caratOffset, y, font );
+         Render_DrawChar( renderData->caratCodepoint, textScale, renderData->position.x + renderData->caratOffset, y, font );
       }
 
       y -= ( font->curGlyphCollection->height + renderData->lineGap );

--- a/OpenGLGame/game.c
+++ b/OpenGLGame/game.c
@@ -19,9 +19,30 @@ internal void Game_UpdateStarAsync( StarUpdateData_t* data );
 
 Bool_t Game_Init( GameData_t* gameData )
 {
+   uint32_t i;
+   float frameTimeAdjustment;
+   Star_t* star = gameData->stars;
+
    if ( !Game_LoadData( gameData ) )
    {
       return False;
+   }
+
+   for ( i = 0; i < STAR_COUNT; i++ )
+   {
+      star->isResting = False;
+      star->movingLeft = Random_Bool();
+      star->pixelsPerSecond = Random_UInt32( STAR_MIN_VELOCITY, STAR_MAX_VELOCITY );
+      star->position.x = (float)Random_UInt32( 0, SCREEN_WIDTH - 1 );
+      star->position.y = (float)Random_UInt32( STAR_MIN_Y, STAR_MAX_Y );
+      star->restSeconds = ( Random_UInt32( 0, STAR_MAX_RESTSECONDS * 1000 ) ) / 1000.0f;
+
+      Sprite_Reset( &( star->sprite ) );
+      frameTimeAdjustment = ( (float)Random_Percent() / 100 ) * 0.5f;
+      star->scale = ( (float)Random_Percent() / 100 );
+      Sprite_ScaleFrameTime( &( star->sprite ), 1.0f + ( Random_Bool() ? frameTimeAdjustment : -frameTimeAdjustment ) );
+
+      star++;
    }
 
    Clock_Init( &( gameData->clock ) );

--- a/OpenGLGame/game.h
+++ b/OpenGLGame/game.h
@@ -37,6 +37,8 @@ typedef struct GameData_t
    Bool_t isEngineRunning;
    Bool_t showDiagnostics;
 
+   GameState_t state;
+   void (*stateInputHandlers[GameState_Count])( void* );
    Star_t stars[STAR_COUNT];
 }
 GameData_t;

--- a/OpenGLGame/game.h
+++ b/OpenGLGame/game.h
@@ -13,6 +13,7 @@
 #include "input.h"
 #include "render.h"
 #include "vector.h"
+#include "menu.h"
 
 typedef struct Star_t
 {
@@ -32,6 +33,8 @@ typedef struct GameData_t
    Clock_t clock;
    KeyState_t keyStates[KeyCode_Count];
    RenderData_t renderData;
+   Menu_t menus[MenuID_Count];
+   MenuID_t curMenuID;
 
    Bool_t isRunning;
    Bool_t isEngineRunning;
@@ -44,10 +47,14 @@ typedef struct GameData_t
 GameData_t;
 
 Bool_t Game_Init( GameData_t* gameData );
+void Game_ClearData( GameData_t* gameData );
 void Game_Run( GameData_t* gameData );
 void Game_PauseEngine( GameData_t* gameData );
 void Game_ResumeEngine( GameData_t* gameData );
 void Game_EmergencySave( GameData_t* gameData );
 void Game_TryClose( GameData_t* gameData );
+
+// game_loader.c
+Bool_t Game_LoadData( GameData_t* gameData );
 
 #endif

--- a/OpenGLGame/game.h
+++ b/OpenGLGame/game.h
@@ -33,8 +33,10 @@ typedef struct GameData_t
    Clock_t clock;
    KeyState_t keyStates[KeyCode_Count];
    RenderData_t renderData;
+
    Menu_t menus[MenuID_Count];
    MenuID_t curMenuID;
+   void (*menuItemInputHandlers[MenuItemID_Count])( void* );
 
    Bool_t isRunning;
    Bool_t isEngineRunning;
@@ -42,6 +44,7 @@ typedef struct GameData_t
 
    GameState_t state;
    void (*stateInputHandlers[GameState_Count])( void* );
+
    Star_t stars[STAR_COUNT];
 }
 GameData_t;

--- a/OpenGLGame/game.h
+++ b/OpenGLGame/game.h
@@ -60,4 +60,7 @@ void Game_TryClose( GameData_t* gameData );
 // game_loader.c
 Bool_t Game_LoadData( GameData_t* gameData );
 
+// game_render.c
+void Game_Render( GameData_t* gameData );
+
 #endif

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -1,0 +1,74 @@
+#include "game.h"
+
+internal Bool_t Game_LoadAssets( GameData_t* gameData );
+internal void Game_LoadMenus( GameData_t* gameData );
+
+Bool_t Game_LoadData( GameData_t* gameData )
+{
+   uint32_t i;
+   Star_t* star;
+
+   if ( !Game_LoadAssets( gameData ) )
+   {
+      return False;
+   }
+
+   Game_LoadMenus( gameData );
+
+   for ( i = 0; i < STAR_COUNT; i++ )
+   {
+      star = &( gameData->stars[i] );
+
+      if ( !Sprite_Init( &( star->sprite ), &( gameData->renderData.textures[TextureID_Star] ), 6, 6, 0.1f ) )
+      {
+         return False;
+      }
+
+      star->isResting = True;
+   }
+
+   return True;
+}
+
+internal Bool_t Game_LoadAssets( GameData_t* gameData )
+{
+   char appDirectory[STRING_SIZE_DEFAULT];
+   char backgroundBmpFilePath[STRING_SIZE_DEFAULT];
+   char starBmpFilePath[STRING_SIZE_DEFAULT];
+   char consolasFontFilePath[STRING_SIZE_DEFAULT];
+   char papyrusFontFilePath[STRING_SIZE_DEFAULT];
+
+   if ( !Platform_GetAppDirectory( appDirectory, STRING_SIZE_DEFAULT ) )
+   {
+      return False;
+   }
+
+   snprintf( backgroundBmpFilePath, STRING_SIZE_DEFAULT, "%sassets\\background.bmp", appDirectory );
+   snprintf( starBmpFilePath, STRING_SIZE_DEFAULT, "%sassets\\star.bmp", appDirectory );
+   snprintf( consolasFontFilePath, STRING_SIZE_DEFAULT, "%sassets\\fonts\\Consolas.gff", appDirectory );
+   snprintf( papyrusFontFilePath, STRING_SIZE_DEFAULT, "%sassets\\fonts\\Papyrus.gff", appDirectory );
+
+   if ( !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Background] ), backgroundBmpFilePath) ||
+        !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Star] ), starBmpFilePath ) ||
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Consolas] ), consolasFontFilePath ) ||
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Papyrus] ), papyrusFontFilePath ) )
+   {
+      return False;
+   }
+
+   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Consolas] ), 12.0f );
+   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Papyrus] ), 48.0f );
+   Font_SetColor( &( gameData->renderData.fonts[FontID_Papyrus] ), 0x003333CC );
+
+   return True;
+}
+
+internal void Game_LoadMenus( GameData_t* gameData )
+{
+   Menu_t* playingMenu = &( gameData->menus[MenuID_Playing] );
+
+   playingMenu->numItems = 2;
+   playingMenu->items = (MenuItem_t*)Platform_MemAlloc( sizeof( MenuItem_t ) * playingMenu->numItems );
+   snprintf( playingMenu->items[0].text, STRING_SIZE_DEFAULT, STR_MENU_KEEPPLAYING );
+   snprintf( playingMenu->items[1].text, STRING_SIZE_DEFAULT, STR_MENU_QUIT );
+}

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -66,7 +66,9 @@ internal void Game_LoadMenus( GameData_t* gameData )
 
    playingMenu->numItems = 2;
    playingMenu->items = (MenuItem_t*)Platform_MemAlloc( sizeof( MenuItem_t ) * playingMenu->numItems );
+   playingMenu->items[0].ID = MenuItemID_KeepPlaying;
    snprintf( playingMenu->items[0].text, STRING_SIZE_DEFAULT, STR_MENU_KEEPPLAYING );
+   playingMenu->items[1].ID = MenuItemID_Quit;
    snprintf( playingMenu->items[1].text, STRING_SIZE_DEFAULT, STR_MENU_QUIT );
    playingMenu->renderData.font = &( gameData->renderData.fonts[FontID_Menu] );
    playingMenu->renderData.caratCodepoint = (uint32_t)( '>' );

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -73,7 +73,10 @@ internal void Game_LoadMenus( GameData_t* gameData )
    playingMenu->renderData.caratCodepoint = (uint32_t)( '>' );
    playingMenu->renderData.position.x = 200.0f;
    playingMenu->renderData.position.y = 500.0f;
+   playingMenu->renderData.textHeight = 24.0f;
    playingMenu->renderData.lineGap = playingMenu->renderData.font->curGlyphCollection->lineGap;
    playingMenu->renderData.caratOffset = -30.0f;
-   playingMenu->caratBlinkSeconds = 0.25f;
+   playingMenu->renderData.textColor = 0xFFFF8800;
+   playingMenu->renderData.caratColor = 0xFFFF8800;
+   playingMenu->caratFadeSeconds = 0.25f;
 }

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -72,8 +72,9 @@ internal void Game_LoadMenus( GameData_t* gameData )
    snprintf( playingMenu->items[1].text, STRING_SIZE_DEFAULT, STR_MENU_QUIT );
    playingMenu->renderData.font = &( gameData->renderData.fonts[FontID_Menu] );
    playingMenu->renderData.caratCodepoint = (uint32_t)( '>' );
-   playingMenu->renderData.x = 100.0f;
-   playingMenu->renderData.y = 500.0f;
+   playingMenu->renderData.position.x = 100.0f;
+   playingMenu->renderData.position.y = 500.0f;
    playingMenu->renderData.lineGap = playingMenu->renderData.font->curGlyphCollection->lineGap;
    playingMenu->renderData.caratOffset = -30.0f;
+   playingMenu->caratBlinkSeconds = 0.25f;
 }

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -50,9 +50,8 @@ internal Bool_t Game_LoadAssets( GameData_t* gameData )
 
    if ( !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Background] ), backgroundBmpFilePath) ||
         !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Star] ), starBmpFilePath ) ||
-        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Diagnostics] ), consolasFontFilePath ) ||
-        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_BrushTeeth] ), papyrusFontFilePath ) || 
-        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Menu] ), consolasFontFilePath ) )
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Consolas] ), consolasFontFilePath ) ||
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Papyrus] ), papyrusFontFilePath ) )
    {
       return False;
    }
@@ -70,9 +69,9 @@ internal void Game_LoadMenus( GameData_t* gameData )
    snprintf( playingMenu->items[0].text, STRING_SIZE_DEFAULT, STR_MENU_KEEPPLAYING );
    playingMenu->items[1].ID = MenuItemID_Quit;
    snprintf( playingMenu->items[1].text, STRING_SIZE_DEFAULT, STR_MENU_QUIT );
-   playingMenu->renderData.font = &( gameData->renderData.fonts[FontID_Menu] );
+   playingMenu->renderData.font = &( gameData->renderData.fonts[FontID_Consolas] );
    playingMenu->renderData.caratCodepoint = (uint32_t)( '>' );
-   playingMenu->renderData.position.x = 100.0f;
+   playingMenu->renderData.position.x = 200.0f;
    playingMenu->renderData.position.y = 500.0f;
    playingMenu->renderData.lineGap = playingMenu->renderData.font->curGlyphCollection->lineGap;
    playingMenu->renderData.caratOffset = -30.0f;

--- a/OpenGLGame/game_load.c
+++ b/OpenGLGame/game_load.c
@@ -50,15 +50,12 @@ internal Bool_t Game_LoadAssets( GameData_t* gameData )
 
    if ( !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Background] ), backgroundBmpFilePath) ||
         !Texture_LoadFromFile( &( gameData->renderData.textures[TextureID_Star] ), starBmpFilePath ) ||
-        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Consolas] ), consolasFontFilePath ) ||
-        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Papyrus] ), papyrusFontFilePath ) )
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Diagnostics] ), consolasFontFilePath ) ||
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_BrushTeeth] ), papyrusFontFilePath ) || 
+        !Font_LoadFromFile( &( gameData->renderData.fonts[FontID_Menu] ), consolasFontFilePath ) )
    {
       return False;
    }
-
-   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Consolas] ), 12.0f );
-   Font_SetGlyphCollectionForHeight( &( gameData->renderData.fonts[FontID_Papyrus] ), 48.0f );
-   Font_SetColor( &( gameData->renderData.fonts[FontID_Papyrus] ), 0x003333CC );
 
    return True;
 }
@@ -71,4 +68,10 @@ internal void Game_LoadMenus( GameData_t* gameData )
    playingMenu->items = (MenuItem_t*)Platform_MemAlloc( sizeof( MenuItem_t ) * playingMenu->numItems );
    snprintf( playingMenu->items[0].text, STRING_SIZE_DEFAULT, STR_MENU_KEEPPLAYING );
    snprintf( playingMenu->items[1].text, STRING_SIZE_DEFAULT, STR_MENU_QUIT );
+   playingMenu->renderData.font = &( gameData->renderData.fonts[FontID_Menu] );
+   playingMenu->renderData.caratCodepoint = (uint32_t)( '>' );
+   playingMenu->renderData.x = 100.0f;
+   playingMenu->renderData.y = 500.0f;
+   playingMenu->renderData.lineGap = playingMenu->renderData.font->curGlyphCollection->lineGap;
+   playingMenu->renderData.caratOffset = -30.0f;
 }

--- a/OpenGLGame/game_render.c
+++ b/OpenGLGame/game_render.c
@@ -1,0 +1,97 @@
+#include "game.h"
+
+internal void Game_RenderWorld( GameData_t* gameData );
+internal void Game_RenderMenu( GameData_t* gameData );
+internal void Game_RenderDiagnostics( GameData_t* gameData );
+
+void Game_Render( GameData_t* gameData )
+{
+   switch ( gameData->state )
+   {
+      case GameState_Playing:
+         Game_RenderWorld( gameData );
+         break;
+      case GameState_Menu:
+         Game_RenderWorld( gameData );
+         Render_DrawRect( 0.0f, 0.0f, (float)SCREEN_WIDTH, (float)SCREEN_HEIGHT, 0x99000000 );
+         Game_RenderMenu( gameData );
+         break;
+   }
+
+   if ( gameData->showDiagnostics )
+   {
+      Game_RenderDiagnostics( gameData );
+   }
+
+   Platform_RenderScreen();
+}
+
+internal void Game_RenderWorld( GameData_t* gameData )
+{
+   uint32_t i;
+   Star_t* star;
+   Font_t* font = &( gameData->renderData.fonts[FontID_Papyrus] );
+
+   Render_ClearScreen();
+   Render_DrawTexture( &( gameData->renderData.textures[TextureID_Background] ), 0.0f, 0.0f, 1.0f );
+
+   Font_SetGlyphCollectionForHeight( font, 48.0f );
+   Font_SetColor( font, 0xFF3333CC );
+   Render_DrawTextLine( STR_BRUSHTEETH, 1.0f, 65.0f, 240.0f, font );
+
+   for ( i = 0; i < STAR_COUNT; i++ )
+   {
+      star = &( gameData->stars[i] );
+      Render_DrawSprite( &( star->sprite ), star->position.x, star->position.y, star->scale );
+   }
+}
+
+internal void Game_RenderMenu( GameData_t* gameData )
+{
+   uint32_t i;
+   Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
+   float y = menu->renderData.position.y;
+   float textScale;
+   MenuItem_t* item = menu->items;
+   MenuRenderData_t* renderData = &( menu->renderData );
+   Font_t* font = renderData->font;
+
+   Font_SetGlyphCollectionForHeight( font, menu->renderData.textHeight );
+   Font_SetColor( font, menu->renderData.textColor );
+   Font_SetCharColor( font, menu->renderData.caratCodepoint, menu->renderData.caratColor );
+
+   textScale = menu->renderData.textHeight / font->curGlyphCollection->height;
+
+   for ( i = 0; i < menu->numItems; i++ )
+   {
+      Render_DrawTextLine( item->text, textScale, renderData->position.x, y, font );
+
+      if ( menu->selectedItem == i )
+      {
+         Render_DrawChar( renderData->caratCodepoint, textScale, renderData->position.x + renderData->caratOffset, y, font );
+      }
+
+      y -= ( font->curGlyphCollection->height + renderData->lineGap );
+      item++;
+   }
+}
+
+internal void Game_RenderDiagnostics( GameData_t* gameData )
+{
+   float y;
+   Font_t* font = &( gameData->renderData.fonts[FontID_Consolas] );
+   char msg[STRING_SIZE_DEFAULT];
+
+   Font_SetGlyphCollectionForHeight( font, 12.0f );
+   Font_SetColor( font, 0xFFFFFFFF );
+
+   y = (float)SCREEN_HEIGHT - font->curGlyphCollection->height - 10.0f;
+   snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMETARGETMICRO, gameData->clock.targetFrameDurationMicro );
+   Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
+   y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
+   snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_FRAMEDURATIONMICRO, gameData->clock.lastFrameDurationMicro );
+   Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
+   y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
+   snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_LAGFRAMES, gameData->clock.lagFrames );
+   Render_DrawTextLine( msg, 1.0f, 10.0f, y, font );
+}

--- a/OpenGLGame/input.h
+++ b/OpenGLGame/input.h
@@ -10,6 +10,7 @@ typedef enum
    KeyCode_Right,
    KeyCode_Down,
 
+   KeyCode_Enter,
    KeyCode_Escape,
 
    KeyCode_F8,

--- a/OpenGLGame/menu.c
+++ b/OpenGLGame/menu.c
@@ -18,7 +18,7 @@ void Menu_ClearItems( Menu_t* menu )
 void Menu_Reset( Menu_t* menu )
 {
    menu->selectedItem = 0;
-   menu->showCarat = True;
+   menu->caratFadingOut = True;
    menu->caratElapsedSeconds = 0.0f;
 }
 
@@ -31,24 +31,37 @@ void Menu_IncrementSelectedItem( Menu_t* menu )
       menu->selectedItem = 0;
    }
 
-   menu->showCarat = True;
+   menu->caratFadingOut = True;
    menu->caratElapsedSeconds = 0.0f;
 }
 
 void Menu_DecrementSelectedItem( Menu_t* menu )
 {
    menu->selectedItem = ( menu->selectedItem == 0 ) ? menu->numItems - 1 : menu->selectedItem - 1;
-   menu->showCarat = True;
+   menu->caratFadingOut = True;
    menu->caratElapsedSeconds = 0.0f;
 }
 
 void Menu_Tick( Menu_t* menu, Clock_t* clock )
 {
+   uint32_t color = menu->renderData.caratColor;
+   uint32_t alpha;
+
+   if ( menu->caratFadeSeconds == 0.0f )
+   {
+      return;
+   }
+
    menu->caratElapsedSeconds += clock->frameDeltaSeconds;
 
-   while ( menu->caratElapsedSeconds > menu->caratBlinkSeconds )
+   while ( menu->caratElapsedSeconds > menu->caratFadeSeconds )
    {
-      TOGGLE_BOOL( menu->showCarat );
-      menu->caratElapsedSeconds -= menu->caratBlinkSeconds;
+      TOGGLE_BOOL( menu->caratFadingOut );
+      menu->caratElapsedSeconds -= menu->caratFadeSeconds;
    }
+
+   alpha = (uint32_t)( 255 * ( menu->caratElapsedSeconds / menu->caratFadeSeconds ) );
+   color &= 0x00FFFFFF;
+   color |= menu->caratFadingOut ? ( ( 255 - alpha ) << 24 ) : ( alpha << 24 );
+   menu->renderData.caratColor = color;
 }

--- a/OpenGLGame/menu.c
+++ b/OpenGLGame/menu.c
@@ -18,6 +18,8 @@ void Menu_ClearItems( Menu_t* menu )
 void Menu_Reset( Menu_t* menu )
 {
    menu->selectedItem = 0;
+   menu->showCarat = True;
+   menu->caratElapsedSeconds = 0.0f;
 }
 
 void Menu_IncrementSelectedItem( Menu_t* menu )
@@ -28,9 +30,25 @@ void Menu_IncrementSelectedItem( Menu_t* menu )
    {
       menu->selectedItem = 0;
    }
+
+   menu->showCarat = True;
+   menu->caratElapsedSeconds = 0.0f;
 }
 
 void Menu_DecrementSelectedItem( Menu_t* menu )
 {
    menu->selectedItem = ( menu->selectedItem == 0 ) ? menu->numItems - 1 : menu->selectedItem - 1;
+   menu->showCarat = True;
+   menu->caratElapsedSeconds = 0.0f;
+}
+
+void Menu_Tick( Menu_t* menu, Clock_t* clock )
+{
+   menu->caratElapsedSeconds += clock->frameDeltaSeconds;
+
+   while ( menu->caratElapsedSeconds > menu->caratBlinkSeconds )
+   {
+      TOGGLE_BOOL( menu->showCarat );
+      menu->caratElapsedSeconds -= menu->caratBlinkSeconds;
+   }
 }

--- a/OpenGLGame/menu.c
+++ b/OpenGLGame/menu.c
@@ -14,3 +14,23 @@ void Menu_ClearItems( Menu_t* menu )
 
    menu->items = 0;
 }
+
+void Menu_Reset( Menu_t* menu )
+{
+   menu->selectedItem = 0;
+}
+
+void Menu_IncrementSelectedItem( Menu_t* menu )
+{
+   menu->selectedItem++;
+
+   if ( menu->selectedItem == menu->numItems )
+   {
+      menu->selectedItem = 0;
+   }
+}
+
+void Menu_DecrementSelectedItem( Menu_t* menu )
+{
+   menu->selectedItem = ( menu->selectedItem == 0 ) ? menu->numItems - 1 : menu->selectedItem - 1;
+}

--- a/OpenGLGame/menu.c
+++ b/OpenGLGame/menu.c
@@ -1,0 +1,16 @@
+#include "menu.h"
+#include "platform.h"
+
+void Menu_ClearItems( Menu_t* menu )
+{
+   uint32_t i;
+   MenuItem_t* item = menu->items;
+
+   for ( i = 0; i < menu->numItems; i++ )
+   {
+      Platform_MemFree( item );
+      item++;
+   }
+
+   menu->items = 0;
+}

--- a/OpenGLGame/menu.h
+++ b/OpenGLGame/menu.h
@@ -11,8 +11,11 @@ typedef struct
    Font_t* font;
    uint32_t caratCodepoint;
    Vector2f_t position;
+   float textHeight;
    float lineGap;
    float caratOffset;
+   uint32_t textColor;
+   uint32_t caratColor;
 }
 MenuRenderData_t;
 
@@ -29,9 +32,9 @@ typedef struct
    uint32_t numItems;
    uint32_t selectedItem;
    MenuRenderData_t renderData;
-   Bool_t showCarat;
+   Bool_t caratFadingOut;
    float caratElapsedSeconds;
-   float caratBlinkSeconds;
+   float caratFadeSeconds;
 }
 Menu_t;
 

--- a/OpenGLGame/menu.h
+++ b/OpenGLGame/menu.h
@@ -3,13 +3,14 @@
 
 #include "common.h"
 #include "font.h"
+#include "vector.h"
+#include "clock.h"
 
 typedef struct
 {
    Font_t* font;
    uint32_t caratCodepoint;
-   float x;
-   float y;
+   Vector2f_t position;
    float lineGap;
    float caratOffset;
 }
@@ -28,6 +29,9 @@ typedef struct
    uint32_t numItems;
    uint32_t selectedItem;
    MenuRenderData_t renderData;
+   Bool_t showCarat;
+   float caratElapsedSeconds;
+   float caratBlinkSeconds;
 }
 Menu_t;
 
@@ -35,5 +39,6 @@ void Menu_ClearItems( Menu_t* menu );
 void Menu_Reset( Menu_t* menu );
 void Menu_IncrementSelectedItem( Menu_t* menu );
 void Menu_DecrementSelectedItem( Menu_t* menu );
+void Menu_Tick( Menu_t* menu, Clock_t* clock );
 
 #endif

--- a/OpenGLGame/menu.h
+++ b/OpenGLGame/menu.h
@@ -2,6 +2,18 @@
 #define MENU_H
 
 #include "common.h"
+#include "font.h"
+
+typedef struct
+{
+   Font_t* font;
+   uint32_t caratCodepoint;
+   float x;
+   float y;
+   float lineGap;
+   float caratOffset;
+}
+MenuRenderData_t;
 
 typedef struct
 {
@@ -14,9 +26,13 @@ typedef struct
    MenuItem_t* items;
    uint32_t numItems;
    uint32_t selectedItem;
+   MenuRenderData_t renderData;
 }
 Menu_t;
 
 void Menu_ClearItems( Menu_t* menu );
+void Menu_Reset( Menu_t* menu );
+void Menu_IncrementSelectedItem( Menu_t* menu );
+void Menu_DecrementSelectedItem( Menu_t* menu );
 
 #endif

--- a/OpenGLGame/menu.h
+++ b/OpenGLGame/menu.h
@@ -1,0 +1,22 @@
+#if !defined( MENU_H )
+#define MENU_H
+
+#include "common.h"
+
+typedef struct
+{
+   char text[STRING_SIZE_DEFAULT];
+}
+MenuItem_t;
+
+typedef struct
+{
+   MenuItem_t* items;
+   uint32_t numItems;
+   uint32_t selectedItem;
+}
+Menu_t;
+
+void Menu_ClearItems( Menu_t* menu );
+
+#endif

--- a/OpenGLGame/menu.h
+++ b/OpenGLGame/menu.h
@@ -17,6 +17,7 @@ MenuRenderData_t;
 
 typedef struct
 {
+   MenuItemID_t ID;
    char text[STRING_SIZE_DEFAULT];
 }
 MenuItem_t;

--- a/OpenGLGame/render.c
+++ b/OpenGLGame/render.c
@@ -6,7 +6,26 @@ internal void Render_PrepareTextureForDrawing( GLuint textureHandle, PixelBuffer
                                                float screenX, float screenY,
                                                float width, float height );
 
-void Render_Clear()
+void Render_ClearData( RenderData_t* renderData )
+{
+   uint32_t i;
+   Texture_t* texture = renderData->textures;
+   Font_t* font = renderData->fonts;
+
+   for ( i = 0; i < TextureID_Count; i++ )
+   {
+      Texture_ClearData( texture );
+      texture++;
+   }
+
+   for ( i = 0; i < FontID_Count; i++ )
+   {
+      Font_ClearData( font );
+      font++;
+   }
+}
+
+void Render_ClearScreen()
 {
    glClearColor( 0.0f, 0.0f, 0.0f, 0.0f );
    glClear( GL_COLOR_BUFFER_BIT );

--- a/OpenGLGame/render.h
+++ b/OpenGLGame/render.h
@@ -15,11 +15,19 @@ RenderData_t;
 void Render_ClearData( RenderData_t* renderData );
 void Render_ClearScreen();
 void Render_DrawRect( float screenX, float screenY, float width, float height, uint32_t color );
-void Render_DrawTextureSection( GLuint textureHandle, PixelBuffer_t* pixelBuffer, float scale,
+void Render_DrawColoredTextureSection( GLuint textureHandle, PixelBuffer_t* pixelBuffer,
+                                       float screenX, float screenY,
+                                       int32_t textureX, int32_t textureY,
+                                       uint32_t sectionWidth, uint32_t sectionHeight,
+                                       float scale, uint32_t color );
+void Render_DrawTextureSection( GLuint textureHandle, PixelBuffer_t* pixelBuffer,
                                 float screenX, float screenY,
                                 int32_t textureX, int32_t textureY,
-                                uint32_t sectionWidth, uint32_t sectionHeight );
-void Render_DrawTexture( Texture_t* texture, float scale, float screenX, float screenY );
+                                uint32_t sectionWidth, uint32_t sectionHeight,
+                                float scale );
+void Render_DrawColoredTexture( Texture_t* texture, float screenX, float screenY, float scale, uint32_t color );
+void Render_DrawTexture( Texture_t* texture, float screenX, float screenY, float scale );
+void Render_DrawColoredSprite( Sprite_t* sprite, float scale, float screenX, float screenY, uint32_t color );
 void Render_DrawSprite( Sprite_t* sprite, float scale, float screenX, float screenY );
 void Render_DrawChar( uint32_t codepoint, float scale, float screenX, float screenY, Font_t* font );
 void Render_DrawTextLine( const char* text, float scale, float screenX, float screenY, Font_t* font );

--- a/OpenGLGame/render.h
+++ b/OpenGLGame/render.h
@@ -5,14 +5,15 @@
 #include "sprite.h"
 #include "font.h"
 
-typedef struct RenderData_t
+typedef struct
 {
    Texture_t textures[TextureID_Count];
    Font_t fonts[FontID_Count];
 }
 RenderData_t;
 
-void Render_Clear();
+void Render_ClearData( RenderData_t* renderData );
+void Render_ClearScreen();
 void Render_DrawRect( float screenX, float screenY, float width, float height, uint32_t color );
 void Render_DrawTextureSection( GLuint textureHandle, PixelBuffer_t* pixelBuffer, float scale,
                                 float screenX, float screenY,

--- a/OpenGLGame/strings.h
+++ b/OpenGLGame/strings.h
@@ -45,5 +45,8 @@
 
 #define STR_BRUSHTEETH                    "(...But don't forget to brush your teeth!)"
 
+#define STR_MENU_KEEPPLAYING              "Keep Playing"
+#define STR_MENU_QUIT                     "Quit"
+
 #endif
 

--- a/OpenGLGame/texture.c
+++ b/OpenGLGame/texture.c
@@ -17,7 +17,7 @@ Bool_t Texture_LoadFromFile( Texture_t* texture, const char* filePath )
    return True;
 }
 
-void Texture_Cleanup( Texture_t* texture )
+void Texture_ClearData( Texture_t* texture )
 {
    if ( texture->pixelBuffer.memory )
    {

--- a/OpenGLGame/texture.h
+++ b/OpenGLGame/texture.h
@@ -13,6 +13,6 @@ typedef struct Texture_t
 Texture_t;
 
 Bool_t Texture_LoadFromFile( Texture_t* texture, const char* filePath );
-void Texture_Cleanup( Texture_t* texture );
+void Texture_ClearData( Texture_t* texture );
 
 #endif

--- a/OpenGLGame/win_platform.c
+++ b/OpenGLGame/win_platform.c
@@ -162,6 +162,7 @@ internal void InitKeyCodeMap()
    g_globals.keyCodeMap[(int)KeyCode_Up] = VK_UP;
    g_globals.keyCodeMap[(int)KeyCode_Right] = VK_RIGHT;
    g_globals.keyCodeMap[(int)KeyCode_Down] = VK_DOWN;
+   g_globals.keyCodeMap[(int)KeyCode_Enter] = VK_RETURN;
    g_globals.keyCodeMap[(int)KeyCode_Escape] = VK_ESCAPE;
    g_globals.keyCodeMap[(int)KeyCode_F8] = VK_F8;
 }

--- a/OpenGLGame/win_platform.c
+++ b/OpenGLGame/win_platform.c
@@ -97,6 +97,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    }
 
    Game_Run( &( g_globals.gameData ) );
+   Game_ClearData( &( g_globals.gameData ) );
 
    return 0;
 }


### PR DESCRIPTION
## Overview

This adds a menu to the "playing" game state, with the options of returning to the game or quitting. It also refactors a few things:

- Textures can now be drawn "colorized".
- Setting a font color no longer changes the glyph pixel buffers, instead we draw the glyphs as colorized textures.
- Fonts should now be sized and colored before each use, so we can just load a single font file once and share it across everything.
- The game rendering code is now in `game_render.c`, because it's probably going to get huge and I don't want it to clutter up `game.c`.
- All memory allocated in `Game_t` should now be freed after the game loop exits (at least I hope it is). I don't really think it's necessary, but there's a chance we might want to re-start the game if something goes wrong.