### PR TITLE
Bugfix: Create the correct amount of threads and show jobs done

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -46,7 +46,7 @@ Bool_t Game_Init( GameData_t* gameData )
    }
 
    Clock_Init( &( gameData->clock ) );
-   Input_Init( gameData->keyStates );
+   Input_Init( &( gameData->inputState ) );
 
    gameData->stateInputHandlers[GameState_Playing] = Game_HandleStateInput_Playing;
    gameData->stateInputHandlers[GameState_Menu] = Game_HandleStateInput_Menu;
@@ -98,7 +98,7 @@ void Game_Run( GameData_t* gameData )
       if ( gameData->isEngineRunning )
       {
          Clock_StartFrame( &( gameData->clock ) );
-         Input_UpdateStates( gameData->keyStates );
+         Input_UpdateState( &( gameData->inputState ) );
          Platform_Tick();
          Game_HandleInput( gameData );
          Game_Tick( gameData );
@@ -145,7 +145,7 @@ void Game_TryClose( GameData_t* gameData )
 
 internal void Game_HandleInput( GameData_t* gameData )
 {
-   if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_F8 ) )
+   if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_F8 ) )
    {
       TOGGLE_BOOL( gameData->showDiagnostics );
    }
@@ -155,7 +155,7 @@ internal void Game_HandleInput( GameData_t* gameData )
 
 internal void Game_HandleStateInput_Playing( GameData_t* gameData )
 {
-   if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Escape ) )
+   if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_Escape ) )
    {
       gameData->curMenuID = MenuID_Playing;
       Menu_Reset( &( gameData->menus[gameData->curMenuID] ) );
@@ -168,20 +168,20 @@ internal void Game_HandleStateInput_Menu( GameData_t* gameData )
 {
    Menu_t* menu = &( gameData->menus[gameData->curMenuID] );
 
-   if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Escape ) )
+   if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_Escape ) )
    {
       gameData->state = GameState_Playing;
       return;
    }
-   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Up ) )
+   else if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_Up ) )
    {
       Menu_DecrementSelectedItem( menu );
    }
-   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Down ) )
+   else if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_Down ) )
    {
       Menu_IncrementSelectedItem( menu );
    }
-   else if ( Input_WasKeyPressed( gameData->keyStates, KeyCode_Enter ) )
+   else if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_Enter ) )
    {
       gameData->menuItemInputHandlers[menu->items[menu->selectedItem].ID]( gameData );
    }

--- a/src/game.c
+++ b/src/game.c
@@ -1,6 +1,7 @@
 #include "game.h"
 #include "image.h"
 #include "random.h"
+#include "rect.h"
 
 typedef struct
 {
@@ -56,7 +57,8 @@ Bool_t Game_Init( GameData_t* gameData )
 
    gameData->isRunning = False;
    gameData->isEngineRunning = True;
-   gameData->showDiagnostics = False;
+   gameData->diagnosticsData.showDiagnostics = False;
+   gameData->diagnosticsData.showThreadJobs = False;
    gameData->state = GameState_Playing;
    gameData->curMenuID = (MenuID_t)0;
 
@@ -147,7 +149,16 @@ internal void Game_HandleInput( GameData_t* gameData )
 {
    if ( Input_WasButtonPressed( &( gameData->inputState ), ButtonCode_F8 ) )
    {
-      TOGGLE_BOOL( gameData->showDiagnostics );
+      TOGGLE_BOOL( gameData->diagnosticsData.showDiagnostics );
+   }
+
+   if ( gameData->diagnosticsData.showDiagnostics &&
+        Input_WasButtonReleased( &( gameData->inputState ), ButtonCode_MouseLeft ) && 
+        Rect_PointInRectF( &( gameData->diagnosticsData.threadJobsToggleArea ),
+                           (float)( gameData->inputState.mousePos.x ),
+                           (float)( gameData->inputState.mousePos.y ) ) )
+   {
+      TOGGLE_BOOL( gameData->diagnosticsData.showThreadJobs );
    }
 
    gameData->stateInputHandlers[gameData->state]( gameData );

--- a/src/game.h
+++ b/src/game.h
@@ -1,7 +1,7 @@
 #if !defined( GAME_H )
 #define GAME_H
 
-#define STAR_COUNT            1024
+#define STAR_COUNT            128
 #define STAR_MIN_Y            146
 #define STAR_MAX_Y            767
 #define STAR_MIN_VELOCITY     20

--- a/src/game.h
+++ b/src/game.h
@@ -39,7 +39,7 @@ Star_t;
 typedef struct GameData_t
 {
    Clock_t clock;
-   KeyState_t keyStates[KeyCode_Count];
+   InputState_t inputState;
    RenderData_t renderData;
 
    Menu_t menus[MenuID_Count];

--- a/src/game.h
+++ b/src/game.h
@@ -15,6 +15,16 @@
 #include "sprite.h"
 #include "font.h"
 #include "menu.h"
+#include "rect.h"
+
+typedef struct DiagnosticsData_t
+{
+   Bool_t showDiagnostics;
+   Bool_t showThreadJobs;
+
+   RectF_t threadJobsToggleArea;
+}
+DiagnosticsData_t;
 
 typedef struct RenderData_t
 {
@@ -40,6 +50,7 @@ typedef struct GameData_t
 {
    Clock_t clock;
    InputState_t inputState;
+   DiagnosticsData_t diagnosticsData;
    RenderData_t renderData;
 
    Menu_t menus[MenuID_Count];
@@ -48,7 +59,6 @@ typedef struct GameData_t
 
    Bool_t isRunning;
    Bool_t isEngineRunning;
-   Bool_t showDiagnostics;
 
    GameState_t state;
    void (*stateInputHandlers[GameState_Count])( void* );

--- a/src/game_render.c
+++ b/src/game_render.c
@@ -96,4 +96,11 @@ internal void Game_RenderDiagnostics( GameData_t* gameData )
    y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
    snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADCOUNT, threadQueue->numThreads );
    Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
+
+   for ( uint32_t i = 0; i < threadQueue->numThreads; i++ )
+   {
+      y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
+      snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADJOBSDONE, i, Platform_GetJobsDoneByThread( i ) );
+      Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
+   }
 }

--- a/src/game_render.c
+++ b/src/game_render.c
@@ -17,7 +17,7 @@ void Game_Render( GameData_t* gameData )
       Game_RenderMenu( gameData );
    }
 
-   if ( gameData->showDiagnostics )
+   if ( gameData->diagnosticsData.showDiagnostics )
    {
       Game_RenderDiagnostics( gameData );
    }
@@ -79,6 +79,8 @@ internal void Game_RenderDiagnostics( GameData_t* gameData )
    float y;
    Font_t* font = &( gameData->renderData.fonts[FontID_Consolas] );
    ThreadQueue_t* threadQueue = Platform_GetThreadQueue();
+   Vector2f_t threadCountTextDimensions;
+
    char msg[STRING_SIZE_DEFAULT];
 
    Font_SetGlyphCollectionForHeight( font, 12.0f );
@@ -97,11 +99,20 @@ internal void Game_RenderDiagnostics( GameData_t* gameData )
    snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADCOUNT, threadQueue->numThreads );
    Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
 
-   for ( uint32_t i = 0; i < threadQueue->numThreads; i++ )
+   threadCountTextDimensions = Font_GetTextDimensions( font, msg );
+   gameData->diagnosticsData.threadJobsToggleArea.pos.x = 10.0f;
+   gameData->diagnosticsData.threadJobsToggleArea.pos.y = y;
+   gameData->diagnosticsData.threadJobsToggleArea.size.x = threadCountTextDimensions.x;
+   gameData->diagnosticsData.threadJobsToggleArea.size.y = threadCountTextDimensions.y;
+
+   if ( gameData->diagnosticsData.showThreadJobs )
    {
-      y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
-      snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADJOBSDONE, i, Platform_GetJobsDoneByThread( i ) );
-      Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
+      for ( uint32_t i = 0; i < threadQueue->numThreads; i++ )
+      {
+         y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
+         snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADJOBSDONE, i, Platform_GetJobsDoneByThread( i ) );
+         Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
+      }
    }
 
    y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );

--- a/src/game_render.c
+++ b/src/game_render.c
@@ -103,4 +103,8 @@ internal void Game_RenderDiagnostics( GameData_t* gameData )
       snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_THREADJOBSDONE, i, Platform_GetJobsDoneByThread( i ) );
       Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
    }
+
+   y -= ( font->curGlyphCollection->height + font->curGlyphCollection->lineGap );
+   snprintf( msg, STRING_SIZE_DEFAULT, STR_DIAG_MOUSEPOS, gameData->inputState.mousePos.x, gameData->inputState.mousePos.y );
+   Blit_TextLine( msg, 1.0f, 10.0f, y, font, FontJustify_Left );
 }

--- a/src/input.c
+++ b/src/input.c
@@ -1,11 +1,11 @@
 #include "input.h"
 
-void Input_Init( KeyState_t* keyStates )
+void Input_Init( InputState_t* inputState )
 {
    uint32_t i;
-   KeyState_t* state = keyStates;
+   ButtonState_t* state = inputState->buttonStates;
 
-   for ( i = 0; i < (int)KeyCode_Count; i++ )
+   for ( i = 0; i < (int)ButtonCode_Count; i++ )
    {
       state->isDown = False;
       state->wasDown = False;
@@ -13,45 +13,45 @@ void Input_Init( KeyState_t* keyStates )
    }
 }
 
-void Input_UpdateStates( KeyState_t* keyStates )
+void Input_UpdateState( InputState_t* inputState )
 {
    uint32_t i;
-   KeyState_t* state = keyStates;
+   ButtonState_t* state = inputState->buttonStates;
 
-   for ( i = 0; i < (uint32_t)KeyCode_Count; i++ )
+   for ( i = 0; i < (uint32_t)ButtonCode_Count; i++ )
    {
       state->wasDown = state->isDown;
       state++;
    }
 }
 
-void Input_PressKey( KeyState_t* keyStates, KeyCode_t keyCode )
+void Input_PressButton( InputState_t* inputState, ButtonCode_t buttonCode )
 {
-   keyStates[(uint32_t)keyCode].isDown = True;
+   inputState->buttonStates[(uint32_t)buttonCode].isDown = True;
 }
 
-void Input_ReleaseKey( KeyState_t* keyStates, KeyCode_t keyCode )
+void Input_ReleaseButton( InputState_t* inputState, ButtonCode_t buttonCode )
 {
-   keyStates[(uint32_t)keyCode].isDown = False;
+   inputState->buttonStates[(uint32_t)buttonCode].isDown = False;
 }
 
-Bool_t Input_WasKeyPressed( KeyState_t* keyStates, KeyCode_t keyCode )
+Bool_t Input_WasButtonPressed( InputState_t* inputState, ButtonCode_t buttonCode )
 {
-   return keyStates[(uint32_t)keyCode].isDown && !keyStates[(uint32_t)keyCode].wasDown;
+   return inputState->buttonStates[(uint32_t)buttonCode].isDown && !inputState->buttonStates[(uint32_t)buttonCode].wasDown;
 }
 
-Bool_t Input_WasKeyReleased( KeyState_t* keyStates, KeyCode_t keyCode )
+Bool_t Input_WasButtonReleased( InputState_t* inputState, ButtonCode_t buttonCode )
 {
-   return !keyStates[(uint32_t)keyCode].isDown && keyStates[(uint32_t)keyCode].wasDown;
+   return !inputState->buttonStates[(uint32_t)buttonCode].isDown && inputState->buttonStates[(uint32_t)buttonCode].wasDown;
 }
 
-Bool_t Input_IsAnyKeyDown( KeyState_t* keyStates )
+Bool_t Input_IsAnyButtonDown( InputState_t* inputState )
 {
    uint32_t i;
 
-   for ( i = 0; i < (uint32_t)KeyCode_Count; i++ )
+   for ( i = 0; i < (uint32_t)ButtonCode_Count; i++ )
    {
-      if ( keyStates[i].isDown )
+      if ( inputState->buttonStates[i].isDown )
       {
          return True;
       }
@@ -60,17 +60,25 @@ Bool_t Input_IsAnyKeyDown( KeyState_t* keyStates )
    return False;
 }
 
-Bool_t Input_WasAnyKeyPressed( KeyState_t* keyStates )
+Bool_t Input_WasAnyButtonPressed( InputState_t* inputState )
 {
    uint32_t i;
 
-   for ( i = 0; i < (uint32_t)KeyCode_Count; i++ )
+   for ( i = 0; i < (uint32_t)ButtonCode_Count; i++ )
    {
-      if ( Input_WasKeyPressed( keyStates, (KeyCode_t)i ) )
+      if ( Input_WasButtonPressed( inputState, (ButtonCode_t)i ) )
       {
          return True;
       }
    }
 
    return False;
+}
+
+void Input_SetMousePos( InputState_t* inputState, int32_t x, int32_t y )
+{
+   inputState->mouseDelta.x = x - inputState->mousePos.x;
+   inputState->mouseDelta.y = y - inputState->mousePos.y;
+   inputState->mousePos.x = x;
+   inputState->mousePos.y = y;
 }

--- a/src/input.h
+++ b/src/input.h
@@ -2,37 +2,50 @@
 #define INPUT_H
 
 #include "common.h"
+#include "vector.h"
 
 typedef enum
 {
-   KeyCode_Left = 0,
-   KeyCode_Up,
-   KeyCode_Right,
-   KeyCode_Down,
+   ButtonCode_Left = 0,
+   ButtonCode_Up,
+   ButtonCode_Right,
+   ButtonCode_Down,
 
-   KeyCode_Enter,
-   KeyCode_Escape,
+   ButtonCode_Enter,
+   ButtonCode_Escape,
 
-   KeyCode_F8,
+   ButtonCode_F8,
 
-   KeyCode_Count
+   ButtonCode_MouseLeft,
+   ButtonCode_MouseRight,
+
+   ButtonCode_Count
 }
-KeyCode_t;
+ButtonCode_t;
 
-typedef struct KeyState_t
+typedef struct ButtonState_t
 {
    Bool_t isDown;
    Bool_t wasDown;
 }
-KeyState_t;
+ButtonState_t;
 
-void Input_Init( KeyState_t* keyStates );
-void Input_UpdateStates( KeyState_t* keyStates );
-void Input_PressKey( KeyState_t* keyStates, KeyCode_t keyCode );
-void Input_ReleaseKey( KeyState_t* keyStates, KeyCode_t keyCode );
-Bool_t Input_WasKeyPressed( KeyState_t* keyStates, KeyCode_t keyCode );
-Bool_t Input_WasKeyReleased( KeyState_t* keyStates, KeyCode_t keyCode );
-Bool_t Input_IsAnyKeyDown( KeyState_t* keyStates );
-Bool_t Input_WasAnyKeyPressed( KeyState_t* keyStates );
+typedef struct InputState_t
+{
+   ButtonState_t buttonStates[ButtonCode_Count];
+   Vector2i32_t mousePos;
+   Vector2i32_t mouseDelta;
+}
+InputState_t;
+
+void Input_Init( InputState_t* inputState );
+void Input_UpdateState( InputState_t* inputState );
+void Input_PressButton( InputState_t* inputState, ButtonCode_t buttonCode );
+void Input_ReleaseButton( InputState_t* inputState, ButtonCode_t buttonCode );
+Bool_t Input_WasButtonPressed( InputState_t* inputState, ButtonCode_t buttonCode );
+Bool_t Input_WasButtonReleased( InputState_t* inputState, ButtonCode_t buttonCode );
+Bool_t Input_IsAnyButtonDown( InputState_t* inputState );
+Bool_t Input_WasAnyButtonPressed( InputState_t* inputState );
+void Input_SetMousePos( InputState_t* inputState, int32_t x, int32_t y );
 
 #endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -30,5 +30,6 @@ Bool_t Platform_GetAppDirectory( char* directory, uint32_t stringSize );
 ThreadQueue_t* Platform_GetThreadQueue();
 Bool_t Platform_AddThreadQueueEntry( void ( *workerFnc )(), void* data );
 void Platform_RunThreadQueue();
+uint64_t Platform_GetJobsDoneByThread( uint32_t threadIndex );
 
 #endif

--- a/src/rect.h
+++ b/src/rect.h
@@ -1,0 +1,20 @@
+#if !defined( RECT_H )
+#define RECT_H
+
+#include "common.h"
+#include "vector.h"
+
+typedef struct RectF_t
+{
+   Vector2f_t pos;
+   Vector2f_t size;
+}
+RectF_t;
+
+inline Bool_t Rect_PointInRectF( RectF_t* rect, float x, float y )
+{
+   return ( x >= rect->pos.x ) && ( x < ( rect->pos.x + rect->size.x ) ) &&
+          ( y >= rect->pos.y ) && ( y < ( rect->pos.y + rect->size.y ) );
+}
+
+#endif

--- a/src/strings.h
+++ b/src/strings.h
@@ -47,7 +47,7 @@
 #define STR_DIAG_FRAMETARGETMICRO         "Target frame microseconds: %lld"
 #define STR_DIAG_FRAMEDURATIONMICRO       "Last frame microseconds: %lld"
 #define STR_DIAG_LAGFRAMES                "Lag frames: %u"
-#define STR_DIAG_THREADCOUNT              "Thread count: %u"
+#define STR_DIAG_THREADCOUNT              "Threads: %u (click for details)"
 #define STR_DIAG_THREADJOBSDONE           "   Jobs done by thread %u: %lld"
 #define STR_DIAG_MOUSEPOS                 "Mouse position: %d, %d"
 

--- a/src/strings.h
+++ b/src/strings.h
@@ -48,6 +48,7 @@
 #define STR_DIAG_FRAMEDURATIONMICRO       "Last frame microseconds: %lld"
 #define STR_DIAG_LAGFRAMES                "Lag frames: %u"
 #define STR_DIAG_THREADCOUNT              "Thread count: %u"
+#define STR_DIAG_THREADJOBSDONE           "   Jobs done by thread %u: %lld"
 
 #define STR_BRUSHTEETH                    "(...But don't forget to brush your teeth!)"
 

--- a/src/strings.h
+++ b/src/strings.h
@@ -49,6 +49,7 @@
 #define STR_DIAG_LAGFRAMES                "Lag frames: %u"
 #define STR_DIAG_THREADCOUNT              "Thread count: %u"
 #define STR_DIAG_THREADJOBSDONE           "   Jobs done by thread %u: %lld"
+#define STR_DIAG_MOUSEPOS                 "Mouse position: %d, %d"
 
 #define STR_BRUSHTEETH                    "(...But don't forget to brush your teeth!)"
 

--- a/src/win_platform.c
+++ b/src/win_platform.c
@@ -582,3 +582,8 @@ void Platform_RunThreadQueue()
    g_globals.threadQueue.completionGoal = 0;
    g_globals.threadQueue.completionCount = 0;
 }
+
+uint64_t Platform_GetJobsDoneByThread( uint32_t threadIndex )
+{
+   return g_globals.threadInfoArray[threadIndex].jobsDone;
+}

--- a/src/win_platform.c
+++ b/src/win_platform.c
@@ -96,6 +96,8 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
       FatalError( STR_WINERR_CREATEWINDOW );
    }
 
+   SetCursor( LoadCursor( 0, IDC_ARROW ) );
+
    InitKeyCodeMap();
    InitOpenGL( g_globals.hWndMain );
    InitThreads();

--- a/src/win_platform.c
+++ b/src/win_platform.c
@@ -105,7 +105,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    Game_Run( &( g_globals.gameData ) );
    Game_ClearData( &( g_globals.gameData ) );
 
-   Platform_Free( g_globals.threadInfoArray, sizeof( Win32ThreadInfo_t ) * g_globals.threadQueue.numThreads );
+   Platform_Free( g_globals.threadInfoArray, sizeof( Win32ThreadInfo_t ) * ( g_globals.threadQueue.numThreads - 1 ) );
 
    assert( g_globals.memAllocated == g_globals.memFreed );
 
@@ -133,7 +133,9 @@ internal void InitThreads()
 
    GetSystemInfo( &sysInfo );
    numThreads = ( sysInfo.dwNumberOfProcessors == 0 ) ? 1 : sysInfo.dwNumberOfProcessors;
-   g_globals.threadInfoArray = (Win32ThreadInfo_t*)Platform_MAlloc( sizeof( Win32ThreadInfo_t ) * numThreads );
+
+   // this array doesn't include the main thread, so only allocate "extra" threads
+   g_globals.threadInfoArray = (Win32ThreadInfo_t*)Platform_MAlloc( sizeof( Win32ThreadInfo_t ) * ( numThreads - 1 ) );
 
    g_globals.threadQueue.numThreads = numThreads;
    g_globals.threadQueue.completionGoal = 0;
@@ -147,7 +149,7 @@ internal void InitThreads()
       FatalError( STR_WINERR_INITTHREADS );
    }
 
-   for ( i = 0; i < numThreads; i++ )
+   for ( i = 0; i < ( numThreads - 1 ); i++ )
    {
       g_globals.threadInfoArray[i].queue = &( g_globals.threadQueue );
       g_globals.threadInfoArray[i].logicalThreadIndex = i;

--- a/src/win_platform.h
+++ b/src/win_platform.h
@@ -18,7 +18,8 @@ typedef struct ThreadQueue_t ThreadQueue_t;
 typedef struct
 {
    ThreadQueue_t* queue;
-   int32_t logicalThreadIndex;
+   uint32_t threadIndex;
+   uint64_t jobsDone;
 }
 Win32ThreadInfo_t;
 

--- a/windows/OpenGLGame/OpenGLGame.vcxproj
+++ b/windows/OpenGLGame/OpenGLGame.vcxproj
@@ -40,7 +40,6 @@
     <ClInclude Include="..\..\src\thread.h" />
     <ClInclude Include="..\..\src\vector.h" />
     <ClInclude Include="..\..\src\win_platform.h" />
-    <ClInclude Include="rect.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\blit.c" />

--- a/windows/OpenGLGame/OpenGLGame.vcxproj
+++ b/windows/OpenGLGame/OpenGLGame.vcxproj
@@ -34,11 +34,13 @@
     <ClInclude Include="..\..\src\platform.h" />
     <ClInclude Include="..\..\src\platform_includes.h" />
     <ClInclude Include="..\..\src\random.h" />
+    <ClInclude Include="..\..\src\rect.h" />
     <ClInclude Include="..\..\src\sprite.h" />
     <ClInclude Include="..\..\src\strings.h" />
     <ClInclude Include="..\..\src\thread.h" />
     <ClInclude Include="..\..\src\vector.h" />
     <ClInclude Include="..\..\src\win_platform.h" />
+    <ClInclude Include="rect.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\blit.c" />

--- a/windows/OpenGLGame/OpenGLGame.vcxproj.filters
+++ b/windows/OpenGLGame/OpenGLGame.vcxproj.filters
@@ -71,6 +71,12 @@
     <ClInclude Include="..\..\src\win_platform.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="rect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\rect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\blit.c">

--- a/windows/OpenGLGame/OpenGLGame.vcxproj.filters
+++ b/windows/OpenGLGame/OpenGLGame.vcxproj.filters
@@ -71,9 +71,6 @@
     <ClInclude Include="..\..\src\win_platform.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="rect.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\rect.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
## Overview

This branch started as a threading fix, I realized that since the main thread also does work in the thread queue, we're creating one more thread than we really need. That work spiraled into showing diagnostic info on the number of jobs completed by each thread, which I wanted to make toggle-able, so I had to add mouse input handling has well. Now if you click on the number of threads in the diagnostic view it will expand to show a list of jobs done. Diagnostics also shows the current position of the mouse in the client area.