### PR TITLE
Re-organize some asset loading and render data init code

### DIFF
--- a/src/assets_file.c
+++ b/src/assets_file.c
@@ -301,7 +301,7 @@ internal Bool_t AssetsFile_InterpretBitmapsChunk( GameData_t* gameData, AssetsFi
          image = &( gameData->renderData.images[entry->ID] );
          Image_ClearData( image );
 
-         if ( !Image_LoadFromBitmapMemory( image, entry->memory, entry->size, entry->ID ) )
+         if ( !Image_LoadFromBitmapMemory( image, entry->memory, entry->size ) )
          {
             return False;
          }
@@ -384,7 +384,6 @@ internal Bool_t AssetsFile_InterpretSpriteBasesChunk( GameData_t* gameData, Asse
          if ( !Sprite_LoadBaseFromMemory( &( gameData->renderData.spriteBases[entry->ID] ),
                                           baseID,
                                           &( gameData->renderData.images[imageID] ),
-                                          (ImageID_t)imageID,
                                           entry->memory,
                                           entry->size ) )
          {

--- a/src/assets_file.c
+++ b/src/assets_file.c
@@ -382,7 +382,6 @@ internal Bool_t AssetsFile_InterpretSpriteBasesChunk( GameData_t* gameData, Asse
       if ( baseID < SpriteBaseID_Count )
       {
          if ( !Sprite_LoadBaseFromMemory( &( gameData->renderData.spriteBases[entry->ID] ),
-                                          baseID,
                                           &( gameData->renderData.images[imageID] ),
                                           entry->memory,
                                           entry->size ) )

--- a/src/assets_file.c
+++ b/src/assets_file.c
@@ -335,7 +335,7 @@ internal Bool_t AssetsFile_InterpretFontsChunk( GameData_t* gameData, AssetsFile
          font = &( gameData->renderData.fonts[entry->ID] );
          Font_ClearData( font );
 
-         if ( !Font_LoadFromMemory( font, entry->memory, entry->size, entry->ID ) )
+         if ( !Font_LoadFromMemory( font, entry->memory, entry->size ) )
          {
             return False;
          }

--- a/src/assets_file.h
+++ b/src/assets_file.h
@@ -5,26 +5,26 @@
 
 typedef struct GameData_t GameData_t;
 
-typedef struct AssetsFileChunkIDOffsetArray_t
+typedef struct AssetsFileOffsetTable_t
 {
-   uint32_t* offsets;
    uint32_t numOffsets;
+   uint32_t* offsets;
 }
-AssetsFileChunkIDOffsetArray_t;
+AssetsFileOffsetTable_t;
 
-typedef struct AssetsFileChunkEntry_t
+typedef struct AssetsFileEntry_t
 {
    uint32_t ID;
    uint32_t size;
    uint8_t* memory;
 }
-AssetsFileChunkEntry_t;
+AssetsFileEntry_t;
 
 typedef struct AssetsFileChunk_t
 {
    uint32_t ID;
    uint32_t numEntries;
-   AssetsFileChunkEntry_t* entries;
+   AssetsFileEntry_t* entries;
 }
 AssetsFileChunk_t;
 

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -12,7 +12,7 @@
 #define BMP_BI_BITFIELDS               3
 
 #define ERROR_RETURN_FALSE( s ) \
-   snprintf( errorMsg, STRING_SIZE_DEFAULT, s, imageID ); \
+   snprintf( errorMsg, STRING_SIZE_DEFAULT, s, (uint32_t)imageID ); \
    Platform_Log( errorMsg ); \
    return False
 
@@ -33,13 +33,13 @@ typedef struct
 BmpData_t;
 
 internal void Bmp_Cleanup( BmpData_t* bmpData, PixelBuffer_t* pixelBuffer );
-internal Bool_t Bmp_ReadHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID );
-internal Bool_t Bmp_ReadDIBHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID );
-internal Bool_t Bmp_ReadPalette( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID );
-internal Bool_t Bmp_VerifyDataSize( BmpData_t* bmpData, uint32_t memSize, uint32_t imageID );
-internal Bool_t Bmp_ReadPixelBuffer( BmpData_t* bmpData, uint8_t* memPos, PixelBuffer_t* pixelBuffer, uint32_t imageID );
+internal Bool_t Bmp_ReadHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID );
+internal Bool_t Bmp_ReadDIBHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID );
+internal Bool_t Bmp_ReadPalette( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID );
+internal Bool_t Bmp_VerifyDataSize( BmpData_t* bmpData, uint32_t memSize, ImageID_t imageID );
+internal Bool_t Bmp_ReadPixelBuffer( BmpData_t* bmpData, uint8_t* memPos, PixelBuffer_t* pixelBuffer, ImageID_t imageID );
 
-Bool_t Bmp_LoadFromMemory( uint8_t* memory, uint32_t memSize, PixelBuffer_t* pixelBuffer, uint32_t imageID )
+Bool_t Bmp_LoadFromMemory( uint8_t* memory, uint32_t memSize, PixelBuffer_t* pixelBuffer, ImageID_t imageID )
 {
    BmpData_t bmpData = { 0 };
    uint8_t* memStartPos;
@@ -84,7 +84,7 @@ internal void Bmp_Cleanup( BmpData_t* bmpData, PixelBuffer_t* pixelBuffer )
    }
 }
 
-internal Bool_t Bmp_ReadHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID )
+internal Bool_t Bmp_ReadHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID )
 {
    char errorMsg[STRING_SIZE_DEFAULT];
 
@@ -121,7 +121,7 @@ internal Bool_t Bmp_ReadHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t me
    return True;
 }
 
-internal Bool_t Bmp_ReadDIBHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID )
+internal Bool_t Bmp_ReadDIBHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID )
 {
    uint8_t leftoverBits;
    uint32_t compressionMethod;
@@ -231,7 +231,7 @@ internal Bool_t Bmp_ReadDIBHeader( BmpData_t* bmpData, uint8_t* memPos, uint32_t
    return True;
 }
 
-internal Bool_t Bmp_ReadPalette( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, uint32_t imageID )
+internal Bool_t Bmp_ReadPalette( BmpData_t* bmpData, uint8_t* memPos, uint32_t memSize, ImageID_t imageID )
 {
    uint32_t i;
    uint32_t paletteSize;
@@ -270,7 +270,7 @@ internal Bool_t Bmp_ReadPalette( BmpData_t* bmpData, uint8_t* memPos, uint32_t m
    return True;
 }
 
-internal Bool_t Bmp_VerifyDataSize( BmpData_t* bmpData, uint32_t memSize, uint32_t imageID )
+internal Bool_t Bmp_VerifyDataSize( BmpData_t* bmpData, uint32_t memSize, ImageID_t imageID )
 {
    char errorMsg[STRING_SIZE_DEFAULT];
 
@@ -282,7 +282,7 @@ internal Bool_t Bmp_VerifyDataSize( BmpData_t* bmpData, uint32_t memSize, uint32
    return True;
 }
 
-internal Bool_t Bmp_ReadPixelBuffer( BmpData_t* bmpData, uint8_t* memPos, PixelBuffer_t* pixelBuffer, uint32_t imageID )
+internal Bool_t Bmp_ReadPixelBuffer( BmpData_t* bmpData, uint8_t* memPos, PixelBuffer_t* pixelBuffer, ImageID_t imageID )
 {
    uint8_t paddingBytes, i;
    uint16_t paletteIndex;

--- a/src/bmp.h
+++ b/src/bmp.h
@@ -5,6 +5,6 @@
 
 typedef struct PixelBuffer_t PixelBuffer_t;
 
-Bool_t Bmp_LoadFromMemory( uint8_t* memory, uint32_t memSize, PixelBuffer_t* pixelBuffer, uint32_t imageID );
+Bool_t Bmp_LoadFromMemory( uint8_t* memory, uint32_t memSize, PixelBuffer_t* pixelBuffer, ImageID_t imageID );
 
 #endif

--- a/src/font.c
+++ b/src/font.c
@@ -3,12 +3,12 @@
 #include "font.h"
 
 #define ERROR_RETURN_FALSE() \
-   snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_FONTERR_MEMORYCORRUPT, fontID ); \
+   snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_FONTERR_MEMORYCORRUPT, (uint32_t)( font->ID ) ); \
    Platform_Log( errorMsg ); \
    Font_ClearData( font ); \
    return False
 
-Bool_t Font_LoadFromMemory( Font_t* font, uint8_t* memory, uint32_t memSize, uint32_t fontID )
+Bool_t Font_LoadFromMemory( Font_t* font, uint8_t* memory, uint32_t memSize )
 {
    uint32_t* memPos32;
    uint32_t bufferSize, bytesRead, i, j, k;

--- a/src/font.h
+++ b/src/font.h
@@ -27,6 +27,7 @@ FontGlyphCollection_t;
 
 typedef struct Font_t
 {
+   FontID_t ID;
    uint32_t codepointOffset;
    uint32_t numGlyphCollections;
    uint32_t numGlyphs;
@@ -36,7 +37,7 @@ typedef struct Font_t
 }
 Font_t;
 
-Bool_t Font_LoadFromMemory( Font_t* font, uint8_t* memory, uint32_t memSize, uint32_t fontID );
+Bool_t Font_LoadFromMemory( Font_t* font, uint8_t* memory, uint32_t memSize );
 void Font_ClearData( Font_t* font );
 Bool_t Font_ContainsChar( Font_t* font, uint32_t codepoint );
 void Font_SetCharColor( Font_t* font, uint32_t codepoint, uint32_t color );

--- a/src/game.c
+++ b/src/game.c
@@ -10,6 +10,7 @@ typedef struct
 }
 StarUpdateData_t;
 
+internal void Game_InitRenderData( GameRenderData_t* renderData );
 internal void Game_HandleInput( GameData_t* gameData );
 internal void Game_HandleStateInput_Playing( GameData_t* gameData );
 internal void Game_HandleStateInput_Menu( GameData_t* gameData );
@@ -24,14 +25,7 @@ Bool_t Game_Init( GameData_t* gameData )
    float frameTimeAdjustment;
    Star_t* star = gameData->stars;
 
-   for ( i = 0; i < (uint32_t)ImageID_Count; i++ )
-   {
-      gameData->renderData.images[i].ID = (ImageID_t)i;
-      gameData->renderData.images[i].pixelBuffer.dimensions.x = 0;
-      gameData->renderData.images[i].pixelBuffer.dimensions.y = 0;
-      gameData->renderData.images[i].pixelBuffer.memory = 0;
-      gameData->renderData.images[i].textureHandle = 0;
-   }
+   Game_InitRenderData( &( gameData->renderData ) );
 
    if ( !Game_LoadData( gameData ) )
    {
@@ -72,6 +66,25 @@ Bool_t Game_Init( GameData_t* gameData )
    gameData->curMenuID = (MenuID_t)0;
 
    return True;
+}
+
+internal void Game_InitRenderData( GameRenderData_t* renderData )
+{
+   uint32_t i;
+
+   for ( i = 0; i < (uint32_t)ImageID_Count; i++ )
+   {
+      renderData->images[i].ID = (ImageID_t)i;
+      renderData->images[i].pixelBuffer.dimensions.x = 0;
+      renderData->images[i].pixelBuffer.dimensions.y = 0;
+      renderData->images[i].pixelBuffer.memory = 0;
+      renderData->images[i].textureHandle = 0;
+   }
+
+   for ( i = 0; i < (uint32_t)SpriteBaseID_Count; i++ )
+   {
+      renderData->spriteBases[i].ID = (SpriteBaseID_t)i;
+   }
 }
 
 void Game_ClearData( GameData_t* gameData )

--- a/src/game.c
+++ b/src/game.c
@@ -24,6 +24,15 @@ Bool_t Game_Init( GameData_t* gameData )
    float frameTimeAdjustment;
    Star_t* star = gameData->stars;
 
+   for ( i = 0; i < (uint32_t)ImageID_Count; i++ )
+   {
+      gameData->renderData.images[i].ID = (ImageID_t)i;
+      gameData->renderData.images[i].pixelBuffer.dimensions.x = 0;
+      gameData->renderData.images[i].pixelBuffer.dimensions.y = 0;
+      gameData->renderData.images[i].pixelBuffer.memory = 0;
+      gameData->renderData.images[i].textureHandle = 0;
+   }
+
    if ( !Game_LoadData( gameData ) )
    {
       return False;

--- a/src/game.c
+++ b/src/game.c
@@ -81,6 +81,11 @@ internal void Game_InitRenderData( GameRenderData_t* renderData )
       renderData->images[i].textureHandle = 0;
    }
 
+   for ( i = 0; i < (uint32_t)FontID_Count; i++ )
+   {
+      renderData->fonts[i].ID = (FontID_t)i;
+   }
+
    for ( i = 0; i < (uint32_t)SpriteBaseID_Count; i++ )
    {
       renderData->spriteBases[i].ID = (SpriteBaseID_t)i;

--- a/src/image.c
+++ b/src/image.c
@@ -1,14 +1,14 @@
 #include "image.h"
 #include "bmp.h"
 
-Bool_t Image_LoadFromBitmapMemory( Image_t* image, uint8_t* memory, uint32_t memSize, uint32_t imageID )
+Bool_t Image_LoadFromBitmapMemory( Image_t* image, uint8_t* memory, uint32_t memSize )
 {
    image->pixelBuffer.memory = 0;
    image->pixelBuffer.dimensions.x = 0;
    image->pixelBuffer.dimensions.y = 0;
    image->textureHandle = 0;
 
-   if ( !Bmp_LoadFromMemory( memory, memSize, &( image->pixelBuffer ), imageID ) )
+   if ( !Bmp_LoadFromMemory( memory, memSize, &( image->pixelBuffer ), image->ID ) )
    {
       return False;
    }

--- a/src/image.h
+++ b/src/image.h
@@ -7,12 +7,13 @@
 
 typedef struct Image_t
 {
+   ImageID_t ID;
    PixelBuffer_t pixelBuffer;
    GLuint textureHandle;
 }
 Image_t;
 
-Bool_t Image_LoadFromBitmapMemory( Image_t* image, uint8_t* memory, uint32_t memSize, uint32_t imageID );
+Bool_t Image_LoadFromBitmapMemory( Image_t* image, uint8_t* memory, uint32_t memSize );
 void Image_ClearData( Image_t* image );
 
 #endif

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -5,7 +5,6 @@
 Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
                                   SpriteBaseID_t baseID,
                                   Image_t* image,
-                                  ImageID_t imageID,
                                   uint8_t* memory,
                                   uint32_t memSize )
 {
@@ -29,7 +28,7 @@ Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
 
    if ( ( imageDim->x % frameDim->x != 0 ) || ( imageDim->y % frameDim->y != 0 ) )
    {
-      snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_SPRITEERR_FRAMEDIMENSIONS, (uint32_t)imageID );
+      snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_SPRITEERR_FRAMEDIMENSIONS, (uint32_t)( image->ID ) );
       Platform_Log( errorMsg );
       return False;
    }

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -2,11 +2,7 @@
 #include "image.h"
 #include "clock.h"
 
-Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
-                                  SpriteBaseID_t baseID,
-                                  Image_t* image,
-                                  uint8_t* memory,
-                                  uint32_t memSize )
+Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base, Image_t* image, uint8_t* memory, uint32_t memSize )
 {
    Vector2ui32_t* imageDim = &( image->pixelBuffer.dimensions );
    Vector2ui32_t* frameDim;
@@ -15,7 +11,7 @@ Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
 
    if ( memSize != 12 )
    {
-      snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_SPRITEERR_MEMORYCORRUPT, (uint32_t)baseID );
+      snprintf( errorMsg, STRING_SIZE_DEFAULT, STR_SPRITEERR_MEMORYCORRUPT, (uint32_t)( base->ID ) );
       Platform_Log( errorMsg );
       return False;
    }

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -29,7 +29,6 @@ Sprite_t;
 Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
                                   SpriteBaseID_t baseID,
                                   Image_t* image,
-                                  ImageID_t imageID,
                                   uint8_t* memory,
                                   uint32_t memSize );
 Bool_t Sprite_LoadFromBase( Sprite_t* sprite, SpriteBase_t* base, float frameSeconds );

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -9,6 +9,7 @@ typedef struct Clock_t Clock_t;
 
 typedef struct SpriteBase_t
 {
+   SpriteBaseID_t ID;
    Image_t* image;
    Vector2ui32_t frameDimensions;
    uint32_t numFrames;
@@ -26,11 +27,7 @@ typedef struct Sprite_t
 }
 Sprite_t;
 
-Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base,
-                                  SpriteBaseID_t baseID,
-                                  Image_t* image,
-                                  uint8_t* memory,
-                                  uint32_t memSize );
+Bool_t Sprite_LoadBaseFromMemory( SpriteBase_t* base, Image_t* image, uint8_t* memory, uint32_t memSize );
 Bool_t Sprite_LoadFromBase( Sprite_t* sprite, SpriteBase_t* base, float frameSeconds );
 void Sprite_Reset( Sprite_t* sprite );
 void Sprite_ScaleFrameTime( Sprite_t* sprite, float scalar );


### PR DESCRIPTION
## Overview

It seemed like some of the naming was pretty weird in the asset file loading code, so this clears some things up. It also gives some render data structs an ID to hold onto, so we don't have to pass it around everywhere.